### PR TITLE
Fix dynamic links

### DIFF
--- a/components/team/Sidebar/LinkSection.tsx
+++ b/components/team/Sidebar/LinkSection.tsx
@@ -8,6 +8,7 @@ export interface LinkConfig {
   external?: boolean;
   count?: number;
   href: string;
+  as?: string;
 }
 
 interface LinkSectionProps {
@@ -23,7 +24,7 @@ export const LinkSection = ({ title, links }: LinkSectionProps) => {
       </Sans>
       {links.map(link => {
         return (
-          <Flex key={link.href} alignItems="center">
+          <Flex key={link.as ?? link.href} alignItems="center">
             {link.external ? (
               <>
                 <Link underlineBehavior="hover" mr={0.5} href={link.href}>
@@ -32,7 +33,7 @@ export const LinkSection = ({ title, links }: LinkSectionProps) => {
                 <External width="10" height="10" color={color("black60")} />
               </>
             ) : (
-              <RouteLink href={link.href} passHref>
+              <RouteLink href={link.href} as={link.as} passHref>
                 <Link
                   color={
                     router.asPath.split("?")[0] === encodeURI(link.href)

--- a/components/team/Sidebar/index.tsx
+++ b/components/team/Sidebar/index.tsx
@@ -20,20 +20,20 @@ import { normalizeParam } from "../../../lib/url";
 
 const search = debounce((router: NextRouter, searchTerm: string) => {
   const searchParam = encodeURI(searchTerm);
-  const pathname = ["team", "[location]", "[org]", "[team]"].some(route =>
-    router.pathname.endsWith(route)
-  )
+  const searchFromCurrentPath = [
+    "team",
+    "[location]",
+    "[org]",
+    "[team]"
+  ].some(route => router.pathname.endsWith(route));
+  const pathname = searchFromCurrentPath ? router.pathname : "/team";
+  const as = pathname.match(/\[[\w-]+\]/)
     ? router.asPath.split("?")[0]
-    : "/team";
+    : undefined;
 
   searchParam
-    ? router.push({
-        pathname,
-        query: { search: searchParam }
-      })
-    : router.push({
-        pathname
-      });
+    ? router.push(pathname, as, { query: { search: searchParam } })
+    : router.push(pathname, as);
 }, 200);
 
 const aggregateMemberLinks = (members, field, prefix) => {
@@ -41,7 +41,8 @@ const aggregateMemberLinks = (members, field, prefix) => {
     .map(([fieldValue, group]) => ({
       text: fieldValue,
       count: (group as any)?.length,
-      href: `/team/${prefix}/${normalizeParam(fieldValue)}`
+      href: `/team/${prefix}/[${prefix}]`,
+      as: `/team/${prefix}/${normalizeParam(fieldValue)}`
     }))
     .filter(({ text }) => text);
 };

--- a/pages/team/index.tsx
+++ b/pages/team/index.tsx
@@ -49,7 +49,11 @@ export const TeamMember = props => {
   const { member, showAvatar = true } = props;
 
   return (
-    <RouterLink href={`/team/member/${normalizeParam(member.name)}`} passHref>
+    <RouterLink
+      href="/team/member/[member]"
+      as={`/team/member/${normalizeParam(member.name)}`}
+      passHref
+    >
       <Link underlineBehavior="none">
         <TeamMemberContainer width="390px" p={1} ml={(!showAvatar && -1) || 0}>
           {showAvatar && (

--- a/pages/team/member/[member].tsx
+++ b/pages/team/member/[member].tsx
@@ -20,10 +20,6 @@ import RouterLink from "next/link";
 
 export { getServerSideProps } from "../index";
 
-// export const getStaticPaths = getPathsForRoute({
-//   route: "name"
-// });
-
 TimeAgo.addLocale(en);
 const timeAgo = new TimeAgo("en-US");
 
@@ -34,7 +30,7 @@ const Member = props => {
     return <Spinner />;
   }
 
-  const name = router.query.name;
+  const name = router.query.member;
   let member, manager;
 
   useMemo(() => {
@@ -150,7 +146,8 @@ const Member = props => {
                 </Serif>
                 <Box style={{ flex: 1 }}>
                   <RouterLink
-                    href={`/team/member/${normalizeParam(manager.name)}`}
+                    href={"/team/member/[member]"}
+                    as={`/team/member/${normalizeParam(manager.name)}`}
                     passHref
                   >
                     <Link>

--- a/pages/team/org/[org].tsx
+++ b/pages/team/org/[org].tsx
@@ -6,8 +6,6 @@ import { NoResults } from "../../../components/team/NoResults";
 
 export { getServerSideProps } from "../index";
 
-// export const getStaticPaths = getPathsForRoute({ route: "org" });
-
 const Organization = props => {
   const router = useRouter();
 

--- a/pages/team/team/[team].tsx
+++ b/pages/team/team/[team].tsx
@@ -6,8 +6,6 @@ import { NoResults } from "../../../components/team/NoResults";
 
 export { getServerSideProps } from "../index";
 
-// export const getStaticPaths = getPathsForRoute({ route: "team" });
-
 const Team = props => {
   const router = useRouter();
 


### PR DESCRIPTION
So evidently for links in `next.js` there's a somewhat weird way that you have to interact with links/routes for dynamic routes.

A dynamic route is defined by a path where either a file or a folder is denoted by being named `[something]`. So `/team/members/[member]` would be an example of this.  

Essentially, you have to have `href` be the _actual_ route (that kind of matches the filepath without the extension) so `href="/team/members/[member]"`. You'll have an `as` prop which is the resolved route so like `as="/team/members/justin"`. 

This was the _actual_ reason why every page was reloading and per was generally slow. 

Read more here: https://nextjs.org/docs/api-reference/next/link#dynamic-routes