### PR TITLE
Improve search speed by using shallow routing

### DIFF
--- a/components/team/Sidebar/index.tsx
+++ b/components/team/Sidebar/index.tsx
@@ -34,9 +34,10 @@ const search = debounce((router: NextRouter, searchTerm: string) => {
   searchParam
     ? router.push(
         { pathname, query: as ? {} : { search: searchParam } },
-        as && { pathname: as, query: { search: searchParam } }
+        as && { pathname: as, query: { search: searchParam } },
+        { shallow: true }
       )
-    : router.push(pathname, as);
+    : router.push(pathname, as, { shallow: true });
 }, 200);
 
 const aggregateMemberLinks = (members, field, prefix) => {

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -8,3 +8,7 @@ export const urlFromReq = (req: IncomingMessage) => {
   const protocol = host.split(":")[0] === "localhost" ? "http" : "https";
   return `${protocol}://${host}`;
 };
+
+export const normalizeSearchTerm = content => {
+  return content.toLowerCase().replace(/\s/g, "");
+};

--- a/lib/useSearch.tsx
+++ b/lib/useSearch.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+import Router, { useRouter } from "next/router";
+import { normalizeSearchTerm } from "./url";
+
+export const useSearch = () => {
+  const router = useRouter();
+  const [searchTerm, setSearchTerm] = useState(router.query.search || "");
+  useEffect(() => {
+    const updateSearchTerm = url => {
+      const term =
+        new URL("http://noop/" + url).searchParams.get("search") ?? "";
+      console.log("calling for", url, "with search", term);
+      setSearchTerm(normalizeSearchTerm(term));
+    };
+    Router.events.on("routeChangeStart", updateSearchTerm);
+  }, []);
+
+  return searchTerm;
+};

--- a/pages/team/index.tsx
+++ b/pages/team/index.tsx
@@ -14,8 +14,9 @@ import { AvatarFallback } from "../../components/AvatarFallback";
 import RouterLink from "next/link";
 import { useRouter } from "next/router";
 import { NoResults as DefaultNoResults } from "../../components/team/NoResults";
-import { normalizeParam, urlFromReq } from "../../lib/url";
+import { normalizeParam, urlFromReq, normalizeSearchTerm } from "../../lib/url";
 import { authorizedPage } from "../../lib/auth";
+import { useSearch } from "../../lib/useSearch";
 
 export const getServerSideProps: GetServerSideProps = authorizedPage(
   async (ctx, fetch) => {
@@ -95,19 +96,13 @@ export const TeamMember = props => {
 
 const TeamNav = props => {
   const { title, data, NoResults = DefaultNoResults } = props;
-  const router = useRouter();
-
-  const normalizeSearchTerm = content => {
-    return content.toLowerCase().replace(/\s/g, "");
-  };
+  const searchTerm = useSearch();
 
   const group = {};
   data
-    .filter(member =>
-      normalizeSearchTerm(member.name).includes(
-        normalizeSearchTerm(router.query.search || "")
-      )
-    )
+    .filter(member => {
+      return normalizeSearchTerm(member.name).includes(searchTerm);
+    })
     .forEach(member => {
       const firstLetter = member.name[0];
       if (!group[firstLetter]) {

--- a/pages/team/location/[location].tsx
+++ b/pages/team/location/[location].tsx
@@ -4,11 +4,6 @@ import { Spinner } from "@artsy/palette";
 import { normalizeParam } from "../../../lib/url";
 import { NoResults } from "../../../components/team/NoResults";
 
-// export const getStaticPaths = getPathsForRoute({
-//   route: "location",
-//   key: "city"
-// });
-
 export { getServerSideProps } from "../index";
 
 const Location = props => {


### PR DESCRIPTION
This greatly increases the speed of seeing search results by using [shallow routing](https://nextjs.org/docs/api-reference/next/link#dynamic-routes). Essentially it won't do a full page reload when the search term as updated, it'll  only update the route. This _does_ mean that the views aren't rerendered, so I added a `useSearch` hook to cause the `Team` component to be rerendered when the search term updates. 